### PR TITLE
added a check for if _P was greater than _MaxP

### DIFF
--- a/lib/PIDController.js
+++ b/lib/PIDController.js
@@ -119,7 +119,7 @@ PIDController.prototype.calculate = function (actualTemperature) {
   // Calculate the P
   this._P = this._Kp * this._e;
 
-  if (this._P) {
+  if (this._P > this._MaxP) {
     this._P = this._MaxP;
   }
   else if (this._P < (-1 * this._MaxP)) {


### PR DESCRIPTION
calculate() was always using MaxP.
